### PR TITLE
Add iOS 7 fonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
 		<option class="ios40">iOS 4</option>
 		<option class="ios50">iOS 5</option>
 		<option class="ios60">iOS 6</option>
+		<option class="ios70">iOS 7</option>
 	</select>
 	</div>
 	<input type="search" placeholder="Search Fonts" results="5" autosave=iosfonts_cached_search_query />
@@ -39,6 +40,10 @@
 <table>
 	<tr class="section_header"><td class="rowheader">Academy Engraved LET</td><td class="label_iphone"></td><td class="label_ipad"></td></tr>
 	<tr><td class="font_face" style="font-family:AcademyEngravedLetPlain">AcademyEngravedLetPlain</td><td class="iphone">5.0</td><td class="ipad">4.3</td></tr>
+
+	<tr class="section_header"><td class="rowheader">Al Nile</td><td class="label_iphone"></td><td class="label_ipad"></td></tr>
+	<tr><td class="font_face" style="font-family:AlNile-Bold">AlNile-Bold</td><td class="iphone">7.0</td><td class="ipad">7.0</td></tr>
+	<tr><td class="font_face" style="font-family:AlNile">AlNile</td><td class="iphone">7.0</td><td class="ipad">7.0</td></tr>
 
 	<tr class="section_header"><td class="rowheader">American Typewriter</td><td class="label_iphone"></td><td class="label_ipad"></td></tr>
 	<tr><td class="font_face" style="font-family:AmericanTypewriter">AmericanTypewriter</td><td class="iphone">3.0</td><td class="ipad">4.3</td></tr>
@@ -54,7 +59,12 @@
 
 
 	<tr class="section_header"><td class="rowheader">Apple SD Gothic Neo</td><td class="label_iphone"></td><td class="label_ipad"></td></tr>
-	<tr><td class="font_face" style="font-family:AppleSDGothicNeo-Bold">AppleSDGothicNeo-Bold</td><td class="iphone">5.0</td><td class="ipad">5.0</td></tr>
+	<tr><td class="font_face" style="font-family:AppleSDGothicNeo-Thin">AppleSDGothicNeo-Thin</td><td class="iphone">7.0</td><td class="ipad">7.0</td></tr>
+	<tr><td class="font_face" style="font-family:AppleSDGothicNeo-Light">AppleSDGothicNeo-Light</td><td class="iphone">7.0</td><td class="ipad">7.0</td></tr>
+	<tr><td class="font_face" style="font-family:AppleSDGothicNeo-Regular">AppleSDGothicNeo-Regular</td><td class="iphone">7.0</td><td class="ipad">7.0</td></tr>
+	<tr><td class="font_face" style="font-family:AppleSDGothicNeo-Medium">AppleSDGothicNeo-Medium</td><td class="iphone">7.0</td><td class="ipad">7.0</td></tr>
+	<tr><td class="font_face" style="font-family:AppleSDGothicNeo-SemiBold">AppleSDGothicNeo-SemiBold</td><td class="iphone">7.0</td><td class="ipad">7.0</td></tr>
+	<tr><td class="font_face" style="font-family:AppleSDGothicNeo-Bold">AppleSDGothicNeo-Bold</td><td class="iphone">7.0</td><td class="ipad">7.0</td></tr>
 	<tr class="info"><td class="font_face" style="font-family:AppleSDGothicNeo-Medium">AppleSDGothicNeo-Medium</td><td class="iphone">4.3</td><td class="ipad">4.3</td></tr>
 
 
@@ -194,6 +204,21 @@
 	<tr><td class="dead font_face" style="font-family:DBLCDTempBlack">DBLCDTempBlack</td><td class="iphone"><s>6.0</s><br/>3.0</td><td class="ipad"><s>6.0</s><br/>4.3</td></tr>
 	
 
+	<tr class="section_header"><td class="rowheader">DIN Alternate</td><td class="label_iphone"></td><td class="label_ipad"></td></tr>
+	<tr><td class="font_face" style="font-family:DINAlternate-Bold">DINAlternate-Bold</td><td class="iphone">7.0</td><td class="ipad">7.0</td></tr>
+
+
+	<tr class="section_header"><td class="rowheader">DIN Condensed</td><td class="label_iphone"></td><td class="label_ipad"></td></tr>
+	<tr><td class="font_face" style="font-family:DINCondensed-Bold">DINCondensed-Bold</td><td class="iphone">7.0</td><td class="ipad">7.0</td></tr>
+
+
+	<tr class="section_header"><td class="rowheader">Damascus</td><td class="label_iphone"></td><td class="label_ipad"></td></tr>
+	<tr><td class="font_face" style="font-family:DamascusBold">DamascusBold</td><td class="iphone">7.0</td><td class="ipad">7.0</td></tr>
+	<tr><td class="font_face" style="font-family:Damascus">Damascus</td><td class="iphone">7.0</td><td class="ipad">7.0</td></tr>
+	<tr><td class="font_face" style="font-family:DamascusMedium">DamascusMedium</td><td class="iphone">7.0</td><td class="ipad">7.0</td></tr>
+	<tr><td class="font_face" style="font-family:DamascusSemiBold">DamascusSemiBold</td><td class="iphone">7.0</td><td class="ipad">7.0</td></tr>
+
+
 	<tr class="section_header"><td class="rowheader">Devanagari Sangam MN</td><td class="label_iphone"></td><td class="label_ipad"></td></tr>
 	<tr><td class="font_face" style="font-family:DevanagariSangamMN">DevanagariSangamMN</td><td class="iphone">3.0</td><td class="ipad">4.3</td></tr>
 	<tr><td class="font_face" style="font-family:DevanagariSangamMN-Bold">DevanagariSangamMN-Bold</td><td class="iphone">3.0</td><td class="ipad">4.3</td></tr>
@@ -205,10 +230,18 @@
 	<tr><td class="font_face" style="font-family:Didot-Italic">Didot-Italic</td><td class="iphone">5.0</td><td class="ipad">4.3</td></tr>
 
 
+	<tr class="section_header"><td class="rowheader">Diwan Mishafi</td><td class="label_iphone"></td><td class="label_ipad"></td></tr>
+	<tr><td class="font_face" style="font-family:DiwanMishafi">DiwanMishafi</td><td class="iphone">7.0</td><td class="ipad">7.0</td></tr>
+
+
 	<tr class="section_header"><td class="rowheader">Euphemia UCAS</td><td class="label_iphone"></td><td class="label_ipad"></td></tr>
 	<tr><td class="font_face" style="font-family:EuphemiaUCAS">EuphemiaUCAS</td><td class="iphone">6.0</td><td class="ipad">6.0</td></tr>
 	<tr><td class="font_face" style="font-family:EuphemiaUCAS-Bold">EuphemiaUCAS-Bold</td><td class="iphone">6.0</td><td class="ipad">6.0</td></tr>
 	<tr><td class="font_face" style="font-family:EuphemiaUCAS-Italic">EuphemiaUCAS-Italic</td><td class="iphone">6.0</td><td class="ipad">6.0</td></tr>
+
+
+	<tr class="section_header"><td class="rowheader">Farah</td><td class="label_iphone"></td><td class="label_ipad"></td></tr>
+	<tr><td class="font_face" style="font-family:Farah">Farah</td><td class="iphone">7.0</td><td class="ipad">7.0</td></tr>
 
 
 	<tr class="section_header"><td class="rowheader">Futura</td><td class="label_iphone"></td><td class="label_ipad"></td></tr>
@@ -286,8 +319,11 @@
 	<tr><td class="font_face" style="font-family:HelveticaNeue-Light">HelveticaNeue-Light</td><td class="iphone">5.0</td><td class="ipad">5.0</td></tr>
 	<tr><td class="font_face" style="font-family:HelveticaNeue-LightItalic">HelveticaNeue-LightItalic</td><td class="iphone">5.0</td><td class="ipad">5.0</td></tr>
 	<tr><td class="font_face" style="font-family:HelveticaNeue-Medium">HelveticaNeue-Medium</td><td class="iphone">5.0</td><td class="ipad">5.0</td></tr>
+	<tr><td class="font_face" style="font-family:HelveticaNeue-MediumItalic">HelveticaNeue-MediumItalic</td><td class="iphone">7.0</td><td class="ipad">7.0</td></tr>
 	<tr><td class="font_face" style="font-family:HelveticaNeue-UltraLight">HelveticaNeue-UltraLight</td><td class="iphone">5.0</td><td class="ipad">5.0</td></tr>
 	<tr><td class="font_face" style="font-family:HelveticaNeue-UltraLightItalic">HelveticaNeue-UltraLightItalic</td><td class="iphone">5.0</td><td class="ipad">5.0</td></tr>
+	<tr><td class="font_face" style="font-family:HelveticaNeue-Thin">HelveticaNeue-Thin</td><td class="iphone">7.0</td><td class="ipad">7.0</td></tr>
+	<tr><td class="font_face" style="font-family:HelveticaNeue-Thin_Italic">HelveticaNeue-Thin_Italic</td><td class="iphone">7.0</td><td class="ipad">7.0</td></tr>
 
 
 	<tr class="section_header"><td class="rowheader">Hiragino Kaku Gothic ProN</td><td class="label_iphone"></td><td class="label_ipad"></td></tr>
@@ -310,6 +346,13 @@
 	<tr><td class="font_face" style="font-family:HoeflerText-Regular">HoeflerText-Regular</td><td class="iphone">5.0</td><td class="ipad">4.3</td></tr>
 
 
+	<tr class="section_header"><td class="rowheader">Iowan Old Style</td><td class="label_iphone"></td><td class="label_ipad"></td></tr>
+	<tr><td class="font_face" style="font-family:IowanOldStyle-Bold">IowanOldStyle-Bold</td><td class="iphone">7.0</td><td class="ipad">7.0</td></tr>
+	<tr><td class="font_face" style="font-family:IowanOldStyle-BoldItalic">IowanOldStyle-BoldItalic</td><td class="iphone">7.0</td><td class="ipad">7.0</td></tr>
+	<tr><td class="font_face" style="font-family:IowanOldStyle-Italic">IowanOldStyle-Italic</td><td class="iphone">7.0</td><td class="ipad">7.0</td></tr>
+	<tr><td class="font_face" style="font-family:IowanOldStyle-Roman">IowanOldStyle-Roman</td><td class="iphone">7.0</td><td class="ipad">7.0</td></tr>
+
+
 	<tr class="section_header"><td class="rowheader">Kailasa</td><td class="label_iphone"></td><td class="label_ipad"></td></tr>
 	<tr><td class="font_face" style="font-family:Kailasa">Kailasa</td><td class="iphone">3.0</td><td class="ipad">4.3</td></tr>
 	<tr><td class="font_face" style="font-family:Kailasa-Bold">Kailasa-Bold</td><td class="iphone">3.0</td><td class="ipad">4.3</td></tr>
@@ -330,6 +373,11 @@
 	<tr><td class="font_face" style="font-family:Marion-Italic">Marion-Italic</td><td class="iphone">5.0</td><td class="ipad">5.0</td></tr>
 	<tr><td class="font_face" style="font-family:Marion-Regular">Marion-Regular</td><td class="iphone">5.0</td><td class="ipad">5.0</td></tr>
 
+	<tr class="section_header"><td class="rowheader">Menlo</td><td class="label_iphone"></td><td class="label_ipad"></td></tr>
+	<tr><td class="font_face" style="font-family:Menlo-BoldItalic">Menlo-BoldItalic</td><td class="iphone">7.0</td><td class="ipad">7.0</td></tr>
+	<tr><td class="font_face" style="font-family:Menlo-Regular">Menlo-Regular</td><td class="iphone">7.0</td><td class="ipad">7.0</td></tr>
+	<tr><td class="font_face" style="font-family:Menlo-Bold">Menlo-Bold</td><td class="iphone">7.0</td><td class="ipad">7.0</td></tr>
+	<tr><td class="font_face" style="font-family:Menlo-Italic">Menlo-Italic</td><td class="iphone">7.0</td><td class="ipad">7.0</td></tr>
 
 	<tr class="section_header"><td class="rowheader">Marker Felt</td><td class="label_iphone"></td><td class="label_ipad"></td></tr>
 	<tr><td class="font_face" style="font-family:MarkerFelt-Thin">MarkerFelt-Thin</td><td class="iphone">3.0</td><td class="ipad">4.3</td></tr>
@@ -370,6 +418,10 @@
 	<tr><td class="font_face" style="font-family:PartyLetPlain">PartyLetPlain</td><td class="iphone">5.0</td><td class="ipad">4.3</td></tr>
 
 
+	<tr class="section_header"><td class="rowheader">Savoye Let Plain</td><td class="label_iphone"></td><td class="label_ipad"></td></tr>
+	<tr><td class="font_face" style="font-family:SavoyeLetPlain">SavoyeLetPlain</td><td class="iphone">7.0</td><td class="ipad">7.0</td></tr>
+
+
 	<tr class="section_header"><td class="rowheader">Sinhala Sangam MN</td><td class="label_iphone"></td><td class="label_ipad"></td></tr>
 	<tr><td class="font_face" style="font-family:SinhalaSangamMN">SinhalaSangamMN</td><td class="iphone">3.0</td><td class="ipad">4.3</td></tr>
 	<tr><td class="font_face" style="font-family:SinhalaSangamMN-Bold">SinhalaSangamMN-Bold</td><td class="iphone">3.0</td><td class="ipad">4.3</td></tr>
@@ -379,6 +431,16 @@
 	<tr><td class="font_face" style="font-family:SnellRoundhand">SnellRoundhand</td><td class="iphone">3.0</td><td class="ipad">4.3</td></tr>
 	<tr><td class="font_face" style="font-family:SnellRoundhand-Black">SnellRoundhand-Black</td><td class="iphone">5.0</td><td class="ipad">5.0</td></tr>
 	<tr><td class="font_face" style="font-family:SnellRoundhand-Bold">SnellRoundhand-Bold</td><td class="iphone">3.0</td><td class="ipad">4.3</td></tr>
+
+	<tr class="section_header"><td class="rowheader">Superclarendon</td><td class="label_iphone"></td><td class="label_ipad"></td></tr>
+	<tr><td class="font_face" style="font-family:Superclarendon-Regular">Superclarendon-Regular</td><td class="iphone">7.0</td><td class="ipad">7.0</td></tr>
+	<tr><td class="font_face" style="font-family:Superclarendon-BoldItalic">Superclarendon-BoldItalic</td><td class="iphone">7.0</td><td class="ipad">7.0</td></tr>
+	<tr><td class="font_face" style="font-family:Superclarendon-Light">Superclarendon-Light</td><td class="iphone">7.0</td><td class="ipad">7.0</td></tr>
+	<tr><td class="font_face" style="font-family:Superclarendon-BlackItalic">Superclarendon-BlackItalic</td><td class="iphone">7.0</td><td class="ipad">7.0</td></tr>
+	<tr><td class="font_face" style="font-family:Superclarendon-Italic">Superclarendon-Italic</td><td class="iphone">7.0</td><td class="ipad">7.0</td></tr>
+	<tr><td class="font_face" style="font-family:Superclarendon-LightItalic">Superclarendon-LightItalic</td><td class="iphone">7.0</td><td class="ipad">7.0</td></tr>
+	<tr><td class="font_face" style="font-family:Superclarendon-Bold">Superclarendon-Bold</td><td class="iphone">7.0</td><td class="ipad">7.0</td></tr>
+	<tr><td class="font_face" style="font-family:Superclarendon-Black">Superclarendon-Black</td><td class="iphone">7.0</td><td class="ipad">7.0</td></tr>
 
 	<tr class="section_header"><td class="rowheader">Symbol</td><td class="label_iphone"></td><td class="label_ipad"></td></tr>
 	<tr><td class="font_face" style="font-family:Symbol">Symbol</td><td class="iphone">6.0</td><td class="ipad">6.0</td></tr>

--- a/js/script.js
+++ b/js/script.js
@@ -47,21 +47,25 @@ $('nav select').change(function(){
 	  // console.log('selectedOS: ' + selectedOS);
 	  switch(selectedOS){
 	    case 'iOS 3':
-	      $('tbody .ios40' || 'tbody .ios50' || 'tbody .ios60').addClass('unavailable');
+	      $('tbody .ios40' || 'tbody .ios50' || 'tbody .ios60' || 'tbody .ios70').addClass('unavailable');
 	      // $('.ios50').addClass('unavailable');
 	      break;
 	    case 'iOS 4':
-	    	$('td:contains(5.0)').closest('tr').addClass('unavailable');
-	    	$('td:contains(6.0)').closest('tr').addClass('unavailable');
+            $('td:contains(5.0)').closest('tr').addClass('unavailable');
+            $('td:contains(6.0)').closest('tr').addClass('unavailable');
+			$('td:contains(7.0)').closest('tr').addClass('unavailable');
 			break;
 	    case 'iOS 5':
-	    	$('td:contains(6.0)').closest('tr').addClass('unavailable');
+            $('td:contains(6.0)').closest('tr').addClass('unavailable');
+			$('td:contains(7.0)').closest('tr').addClass('unavailable');
 	    	break;
 	    case 'iOS 6':
-	    	$('td.dead').closest('tr').addClass('unavailable');
+			$('td:contains(7.0)').closest('tr').addClass('unavailable');
 	    	break;
+		case 'iOS 7':
+			$('td.dead').closest('tr').addClass('unavailable');
 	    default:
-	     	$('tr').removeClass('unavailable');
+			$('tr').removeClass('unavailable');
 	  }
 	  previousSelectedOS = selectedOS;
 	  countFonts();
@@ -115,7 +119,7 @@ $('.font_face').click(function(){
 
 function setup(){
 	$('header#main').append('<div class="count"><div class="font_faces">Faces: <b>260</b></div></div>');
-	$('nav select').val('iOS 6');
+	$('nav select').val('iOS 7');
 }
 
 function countFonts() {


### PR DESCRIPTION
Added whatever showed up in

```
    const char *format = "<tr><td class=\"font_face\" style=\"font-family:%1$s\">%1$s</td><td class=\"iphone\">7.0</td><td class=\"ipad\">7.0</td></tr>\n";
    for (NSString *familyName in [UIFont familyNames]) {
        for (NSString *fontName in [UIFont fontNamesForFamilyName:familyName]) {
            printf(format, [fontName UTF8String]);
        }
    }
```

that wasn't already in the list.
